### PR TITLE
Strip any remaining non-numerical characters

### DIFF
--- a/data/genconfig
+++ b/data/genconfig
@@ -1,7 +1,12 @@
 #!/bin/sh
-height=$(xrandr | grep ' connected' | awk '{print $4}' | sed -e 's/^\(.*\)x\(.*\)+\(.*\)+\(.*\)/\2/g')
 
-if [[ $height == "1080" ]]; then
+# use grep -v '[^0-9]' to strip non-numbers
+height=$(xrandr | grep ' connected' | awk '{print $4}' | sed -e 's/^\(.*\)x\(.*\)+\(.*\)+\(.*\)/\2/g' | grep -v '[^0-9]')
+
+# shorter and still POSIX compliant
+# height=$(xrandr | grep ' connected' | awk '{print $4}' | awk -F'x' '{print $1}' | grep -o '[0-9]*')
+
+if (( height == 1080 )); then
 	cp -f $(dirname $0)/config-1080 $(dirname $0)/clearine.conf
 else
 	cp -f $(dirname $0)/config-768 $(dirname $0)/clearine.conf


### PR DESCRIPTION
This may be an issue related to having more than one monitor connected but when checking the current monitor's resolution via `$height` I get additional characters in the string.
This causes `[[ $height == "1080" ]]` to fail.

I simply added an additional `grep` to remove any non-numbers from the final string.

I also added an alternative solution in case you want to avoid complex `sed` expressions

This can also be done using `python` *(courtesy of `al-xinerama-prop`)*, though it is a touch slower, it does however get the current monitor's resolution, rather than the first match *(as in the `shell` version)*

```
height=$(python -c "import gi
gi.require_version('Gtk', '3.0')
from gi.repository import Gtk

try:
    active_window = Gtk.Window()
    screen = active_window.get_screen()
    active_monitor = screen.get_monitor_at_window(screen.get_active_window())
    monitor = screen.get_monitor_geometry(active_monitor)
    print(monitor.height)
except:
    print('Not running under X')
")
```

I just got browsing code and can't help myself, feel free to reject if you don't think it's needed

Cheers